### PR TITLE
feat(auth): ユーザー登録・ログイン機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,18 @@ gh issue create --title "タイトル" --body "概要" --label "feature"
 
 Issue 番号を必ず控える。以降のブランチ名・コミット・PR すべてに使用する。
 
-### 2. ブランチ命名規則
+### 2. 実装開始前に必ず Issue 対応ブランチを切る
+
+Issue を作成したら、コードを一行も書く前に必ずブランチを作成する。
+ブランチなしで `main` 上に直接コミットしてはならない。
+
+```bash
+git switch main
+git pull origin main
+git switch -c feature/#<Issue番号>-<機能名>
+```
+
+### 3. ブランチ命名規則
 
 必ず `main` から派生させ、以下の形式で命名する:
 
@@ -102,13 +113,13 @@ git pull origin main
 git switch -c feature/#1-add-auth
 ```
 
-### 3. `main` への直接プッシュ禁止
+### 4. `main` への直接プッシュ禁止
 
 `git push origin main` は絶対に実行しない。
 `git push --force` / `git push -f` も禁止。
 必ずブランチを作成し、Pull Request 経由でマージする。
 
-### 4. コミットメッセージ規則（Conventional Commits）
+### 5. コミットメッセージ規則（Conventional Commits）
 
 形式: `<type>(<scope>): <概要（日本語）>`
 
@@ -135,7 +146,7 @@ docs(readme): セットアップ手順を更新
 chore(ci): GitHub Actions バックエンドCIを追加
 ```
 
-### 5. ポート競合時の対処ルール
+### 6. ポート競合時の対処ルール
 
 | サーバー | ポート | 確認・停止コマンド |
 |----------|--------|-------------------|
@@ -144,7 +155,7 @@ chore(ci): GitHub Actions バックエンドCIを追加
 
 別ポートでの起動は禁止（Next.js rewrites 設定が崩れる）。
 
-### 6. Pull Request のルール
+### 7. Pull Request のルール
 
 - PR タイトル: コミットメッセージと同じ形式
 - PR 本文: 必ず `Closes #<Issue番号>` または `Fixes #<Issue番号>` を含める

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takatoseki0107/nudge-me/backend/internal/service"
+)
+
+type AuthHandler struct {
+	authService *service.AuthService
+}
+
+func NewAuthHandler(authService *service.AuthService) *AuthHandler {
+	return &AuthHandler{authService: authService}
+}
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func (h *AuthHandler) Register(c echo.Context) error {
+	var req registerRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.Email == "" || req.Password == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email and password are required")
+	}
+	if len(req.Password) < 8 {
+		return echo.NewHTTPError(http.StatusBadRequest, "password must be at least 8 characters")
+	}
+
+	user, err := h.authService.Register(req.Email, req.Password)
+	if err != nil {
+		if err.Error() == "email already registered" {
+			return echo.NewHTTPError(http.StatusConflict, err.Error())
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "registration failed")
+	}
+
+	return c.JSON(http.StatusCreated, map[string]interface{}{
+		"id":    user.ID,
+		"email": user.Email,
+	})
+}
+
+func (h *AuthHandler) Login(c echo.Context) error {
+	var req loginRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.Email == "" || req.Password == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email and password are required")
+	}
+
+	token, user, err := h.authService.Login(req.Email, req.Password)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"token": token,
+		"user": map[string]interface{}{
+			"id":    user.ID,
+			"email": user.Email,
+		},
+	})
+}
+
+func (h *AuthHandler) Logout(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"message": "logged out"})
+}

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -6,23 +6,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// AuthHandler handles authentication endpoints
-type AuthHandler struct{}
-
-func NewAuthHandler() *AuthHandler { return &AuthHandler{} }
-
-func (h *AuthHandler) Register(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-func (h *AuthHandler) Login(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-func (h *AuthHandler) Logout(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]string{"message": "logged out"})
-}
-
 // PersonalityHandler handles personality quiz endpoints
 type PersonalityHandler struct{}
 

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"github.com/takatoseki0107/nudge-me/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+type UserRepository struct {
+	db *gorm.DB
+}
+
+func NewUserRepository(db *gorm.DB) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+func (r *UserRepository) Create(user *model.User) error {
+	return r.db.Create(user).Error
+}
+
+func (r *UserRepository) FindByEmail(email string) (*model.User, error) {
+	var user model.User
+	if err := r.db.Where("email = ?", email).First(&user).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (r *UserRepository) FindByID(id uint) (*model.User, error) {
+	var user model.User
+	if err := r.db.First(&user, id).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/takatoseki0107/nudge-me/backend/internal/model"
+	"github.com/takatoseki0107/nudge-me/backend/internal/repository"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+type AuthService struct {
+	userRepo  *repository.UserRepository
+	jwtSecret []byte
+}
+
+func NewAuthService(userRepo *repository.UserRepository, jwtSecret string) *AuthService {
+	return &AuthService{
+		userRepo:  userRepo,
+		jwtSecret: []byte(jwtSecret),
+	}
+}
+
+func (s *AuthService) Register(email, password string) (*model.User, error) {
+	_, err := s.userRepo.FindByEmail(email)
+	if err == nil {
+		return nil, errors.New("email already registered")
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+
+	user := &model.User{
+		Email:        email,
+		PasswordHash: string(hash),
+		AICharacter:  "kind",
+	}
+	if err := s.userRepo.Create(user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func (s *AuthService) Login(email, password string) (string, *model.User, error) {
+	user, err := s.userRepo.FindByEmail(email)
+	if err != nil {
+		return "", nil, errors.New("invalid email or password")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
+		return "", nil, errors.New("invalid email or password")
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id": user.ID,
+		"exp":     time.Now().Add(72 * time.Hour).Unix(),
+	})
+	tokenStr, err := token.SignedString(s.jwtSecret)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return tokenStr, user, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/takatoseki0107/nudge-me/backend/internal/handler"
 	custommiddleware "github.com/takatoseki0107/nudge-me/backend/internal/middleware"
 	"github.com/takatoseki0107/nudge-me/backend/internal/model"
+	"github.com/takatoseki0107/nudge-me/backend/internal/repository"
+	"github.com/takatoseki0107/nudge-me/backend/internal/service"
 )
 
 func main() {
@@ -42,7 +44,10 @@ func main() {
 
 	jwtSecret := getEnv("JWT_SECRET", "change-me")
 
-	authHandler := handler.NewAuthHandler()
+	userRepo := repository.NewUserRepository(db)
+	authService := service.NewAuthService(userRepo, jwtSecret)
+
+	authHandler := handler.NewAuthHandler(authService)
 	personalityHandler := handler.NewPersonalityHandler()
 	decisionHandler := handler.NewDecisionHandler()
 	userHandler := handler.NewUserHandler()

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { getToken, clearToken } from "@/lib/auth";
+
+export default function DashboardPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push("/login");
+    }
+  }, [router]);
+
+  function handleLogout() {
+    clearToken();
+    router.push("/login");
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold mb-4">NudgeMe</h1>
+        <p className="text-gray-600 mb-8">ログインに成功しました</p>
+        <button
+          onClick={handleLogout}
+          className="px-6 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg transition-colors"
+        >
+          ログアウト
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { login, saveToken } from "@/lib/auth";
+import { Suspense } from "react";
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const justRegistered = searchParams.get("registered") === "1";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const { token } = await login(email, password);
+      saveToken(token);
+      router.push("/dashboard");
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? "メールアドレスまたはパスワードが正しくありません";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+        <h1 className="text-2xl font-bold text-center mb-6">ログイン</h1>
+
+        {justRegistered && (
+          <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-700 rounded-lg text-sm">
+            登録が完了しました。ログインしてください。
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="example@email.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-semibold rounded-lg transition-colors"
+          >
+            {loading ? "ログイン中..." : "ログイン"}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          アカウントをお持ちでない方は{" "}
+          <Link href="/register" className="text-blue-600 hover:underline">
+            新規登録
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { register } from "@/lib/auth";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      await register(email, password);
+      router.push("/login?registered=1");
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? "登録に失敗しました";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+        <h1 className="text-2xl font-bold text-center mb-6">アカウント登録</h1>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="example@email.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              パスワード（8文字以上）
+            </label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-semibold rounded-lg transition-colors"
+          >
+            {loading ? "登録中..." : "登録する"}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          すでにアカウントをお持ちの方は{" "}
+          <Link href="/login" className="text-blue-600 hover:underline">
+            ログイン
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import api from "./api";
+
+export interface AuthUser {
+  id: number;
+  email: string;
+}
+
+export async function register(email: string, password: string): Promise<AuthUser> {
+  const res = await api.post<AuthUser>("/auth/register", { email, password });
+  return res.data;
+}
+
+export async function login(
+  email: string,
+  password: string
+): Promise<{ token: string; user: AuthUser }> {
+  const res = await api.post<{ token: string; user: AuthUser }>("/auth/login", {
+    email,
+    password,
+  });
+  return res.data;
+}
+
+export async function logout(): Promise<void> {
+  await api.post("/auth/logout");
+  localStorage.removeItem("nudge_token");
+}
+
+export function saveToken(token: string): void {
+  localStorage.setItem("nudge_token", token);
+}
+
+export function getToken(): string | null {
+  return localStorage.getItem("nudge_token");
+}
+
+export function clearToken(): void {
+  localStorage.removeItem("nudge_token");
+}


### PR DESCRIPTION
## 概要

Issue #1 のユーザー登録・ログイン機能を実装します。

## 変更内容

### バックエンド

- `internal/repository/user.go` — UserRepository（Create / FindByEmail / FindByID）
- `internal/service/auth.go` — AuthService（Register / Login）
  - パスワードは bcrypt でハッシュ化
  - ログイン成功時に JWT（有効期限72時間）を発行
- `internal/handler/auth.go` — AuthHandler に切り出し
  - `POST /api/v1/auth/register` — メール・パスワードでユーザー登録
  - `POST /api/v1/auth/login` — JWT 発行
  - `POST /api/v1/auth/logout` — クライアント側トークン破棄（ステートレス）
- `main.go` — UserRepository・AuthService を DI で接続

### フロントエンド

- `src/lib/auth.ts` — register / login / logout / saveToken / getToken / clearToken
- `src/app/register/page.tsx` — 登録フォーム（バリデーション付き）
- `src/app/login/page.tsx` — ログインフォーム、成功後 /dashboard へリダイレクト
- `src/app/dashboard/page.tsx` — ログイン保護スタブ（未ログインで /login へリダイレクト）
- JWT は `localStorage`（キー: `nudge_token`）に保存

## テスト手順

- [x] `cd backend && go run main.go` でサーバーが起動する
- [x] `POST /api/v1/auth/register` でユーザー登録できる
- [x] 同メールで再登録すると 409 Conflict が返る
- [x] `POST /api/v1/auth/login` で JWT が返る
- [x] 誤パスワードで 401 Unauthorized が返る
- [x] フロントエンドで /register → /login → /dashboard の遷移が動作する
- [x] ログアウト後に /dashboard へアクセスすると /login にリダイレクトされる

Closes #1