### PR TITLE
feat(personality): 性格診断機能を実装

### DIFF
--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -6,19 +6,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// PersonalityHandler handles personality quiz endpoints
-type PersonalityHandler struct{}
-
-func NewPersonalityHandler() *PersonalityHandler { return &PersonalityHandler{} }
-
-func (h *PersonalityHandler) GetQuestions(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-func (h *PersonalityHandler) SaveResult(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
 // DecisionHandler handles decision endpoints
 type DecisionHandler struct{}
 
@@ -41,23 +28,6 @@ func (h *DecisionHandler) Get(c echo.Context) error {
 }
 
 func (h *DecisionHandler) UpdateRegret(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-// UserHandler handles user profile endpoints
-type UserHandler struct{}
-
-func NewUserHandler() *UserHandler { return &UserHandler{} }
-
-func (h *UserHandler) GetMe(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-func (h *UserHandler) UpdateCharacter(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
-}
-
-func (h *UserHandler) UpdatePersonality(c echo.Context) error {
 	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
 }
 

--- a/backend/internal/handler/personality.go
+++ b/backend/internal/handler/personality.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takatoseki0107/nudge-me/backend/internal/service"
+)
+
+type PersonalityHandler struct {
+	svc *service.PersonalityService
+}
+
+func NewPersonalityHandler(svc *service.PersonalityService) *PersonalityHandler {
+	return &PersonalityHandler{svc: svc}
+}
+
+func (h *PersonalityHandler) GetQuestions(c echo.Context) error {
+	questions, err := h.svc.GetQuestions()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch questions")
+	}
+	return c.JSON(http.StatusOK, questions)
+}
+
+type saveResultRequest struct {
+	Answers []string `json:"answers"`
+}
+
+func (h *PersonalityHandler) SaveResult(c echo.Context) error {
+	userID := c.Get("userID").(uint)
+
+	var req saveResultRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if len(req.Answers) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "answers are required")
+	}
+
+	pt, err := h.svc.SaveResult(userID, req.Answers)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save result")
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"personality_type": pt})
+}

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takatoseki0107/nudge-me/backend/internal/repository"
+)
+
+type UserHandler struct {
+	userRepo *repository.UserRepository
+}
+
+func NewUserHandler(userRepo *repository.UserRepository) *UserHandler {
+	return &UserHandler{userRepo: userRepo}
+}
+
+func (h *UserHandler) GetMe(c echo.Context) error {
+	userID := c.Get("userID").(uint)
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "user not found")
+	}
+	return c.JSON(http.StatusOK, user)
+}
+
+func (h *UserHandler) UpdateCharacter(c echo.Context) error {
+	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
+}
+
+func (h *UserHandler) UpdatePersonality(c echo.Context) error {
+	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
+}

--- a/backend/internal/repository/personality.go
+++ b/backend/internal/repository/personality.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"github.com/takatoseki0107/nudge-me/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+type PersonalityRepository struct {
+	db *gorm.DB
+}
+
+func NewPersonalityRepository(db *gorm.DB) *PersonalityRepository {
+	return &PersonalityRepository{db: db}
+}
+
+func (r *PersonalityRepository) FindAllQuestions() ([]model.PersonalityQuestion, error) {
+	var questions []model.PersonalityQuestion
+	if err := r.db.Order("id").Find(&questions).Error; err != nil {
+		return nil, err
+	}
+	return questions, nil
+}
+
+func (r *PersonalityRepository) CountQuestions() (int64, error) {
+	var count int64
+	return count, r.db.Model(&model.PersonalityQuestion{}).Count(&count).Error
+}
+
+func (r *PersonalityRepository) SeedQuestions(questions []model.PersonalityQuestion) error {
+	return r.db.Create(&questions).Error
+}
+
+func (r *PersonalityRepository) UpdatePersonalityType(userID uint, personalityType string) error {
+	return r.db.Model(&model.User{}).Where("id = ?", userID).
+		Update("personality_type", personalityType).Error
+}

--- a/backend/internal/service/personality.go
+++ b/backend/internal/service/personality.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"github.com/takatoseki0107/nudge-me/backend/internal/model"
+	"github.com/takatoseki0107/nudge-me/backend/internal/repository"
+)
+
+// personalityTypes defines evaluation order; earlier index wins on tie.
+var personalityTypes = []string{"analytical", "spontaneous", "empathetic", "competitive"}
+
+type PersonalityService struct {
+	repo *repository.PersonalityRepository
+}
+
+func NewPersonalityService(repo *repository.PersonalityRepository) *PersonalityService {
+	return &PersonalityService{repo: repo}
+}
+
+func (s *PersonalityService) GetQuestions() ([]model.PersonalityQuestion, error) {
+	return s.repo.FindAllQuestions()
+}
+
+// DetermineType tallies answers and returns the personality type with the most votes.
+// On tie, the type that appears earlier in personalityTypes wins.
+func (s *PersonalityService) DetermineType(answers []string) string {
+	counts := make(map[string]int, len(personalityTypes))
+	for _, a := range answers {
+		counts[a]++
+	}
+
+	best := personalityTypes[0]
+	for _, t := range personalityTypes[1:] {
+		if counts[t] > counts[best] {
+			best = t
+		}
+	}
+	return best
+}
+
+func (s *PersonalityService) SaveResult(userID uint, answers []string) (string, error) {
+	pt := s.DetermineType(answers)
+	if err := s.repo.UpdatePersonalityType(userID, pt); err != nil {
+		return "", err
+	}
+	return pt, nil
+}
+
+func (s *PersonalityService) SeedIfEmpty() error {
+	count, err := s.repo.CountQuestions()
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	return s.repo.SeedQuestions(defaultQuestions())
+}
+
+func defaultQuestions() []model.PersonalityQuestion {
+	return []model.PersonalityQuestion{
+		{
+			Question: "新しいレストランに行くとき、どちらを選びますか？",
+			Options:  model.JSONStringSlice{"メニューをしっかり調べてから決める（analytical）", "その場の気分で直感的に決める（spontaneous）"},
+		},
+		{
+			Question: "友人が悩んでいるとき、あなたはどうしますか？",
+			Options:  model.JSONStringSlice{"一緒に解決策を考える（analytical）", "まず気持ちに寄り添って話を聞く（empathetic）"},
+		},
+		{
+			Question: "休日の過ごし方として近いのはどちらですか？",
+			Options:  model.JSONStringSlice{"予定を立てて効率よく動く（analytical）", "思いつきで行動する（spontaneous）"},
+		},
+		{
+			Question: "チームでプロジェクトに取り組むとき、あなたの役割は？",
+			Options:  model.JSONStringSlice{"全体をまとめてリードする（competitive）", "メンバーのサポートに回る（empathetic）"},
+		},
+		{
+			Question: "買い物をするとき、どちらに近いですか？",
+			Options:  model.JSONStringSlice{"比較・検討してから購入する（analytical）", "気に入ったらすぐ買う（spontaneous）"},
+		},
+		{
+			Question: "目標に向かうとき、どちらのタイプですか？",
+			Options:  model.JSONStringSlice{"結果にこだわって最善を尽くす（competitive）", "プロセスを楽しみながら進む（empathetic）"},
+		},
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -47,10 +47,16 @@ func main() {
 	userRepo := repository.NewUserRepository(db)
 	authService := service.NewAuthService(userRepo, jwtSecret)
 
+	personalityRepo := repository.NewPersonalityRepository(db)
+	personalitySvc := service.NewPersonalityService(personalityRepo)
+	if err := personalitySvc.SeedIfEmpty(); err != nil {
+		log.Fatalf("failed to seed personality questions: %v", err)
+	}
+
 	authHandler := handler.NewAuthHandler(authService)
-	personalityHandler := handler.NewPersonalityHandler()
+	personalityHandler := handler.NewPersonalityHandler(personalitySvc)
 	decisionHandler := handler.NewDecisionHandler()
-	userHandler := handler.NewUserHandler()
+	userHandler := handler.NewUserHandler(userRepo)
 	statsHandler := handler.NewStatsHandler()
 
 	e := echo.New()

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { login, saveToken } from "@/lib/auth";
+import { getMe } from "@/lib/user";
 import { Suspense } from "react";
 
 function LoginForm() {
@@ -24,7 +25,8 @@ function LoginForm() {
     try {
       const { token } = await login(email, password);
       saveToken(token);
-      router.push("/dashboard");
+      const user = await getMe();
+      router.push(user.personality_type ? "/dashboard" : "/quiz");
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { message?: string } } })?.response?.data

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getQuestions, saveResult } from "@/lib/personality";
+import { getToken } from "@/lib/auth";
+import type { PersonalityQuestion, PersonalityType } from "@/types";
+
+const PERSONALITY_LABELS: Record<PersonalityType, string> = {
+  analytical: "分析タイプ",
+  spontaneous: "直感タイプ",
+  empathetic: "共感タイプ",
+  competitive: "競争タイプ",
+};
+
+// Options are stored as "テキスト（type）" — extract the type keyword inside ().
+function extractType(option: string): PersonalityType {
+  const match = option.match(/（(\w+)）$/);
+  return (match?.[1] ?? "analytical") as PersonalityType;
+}
+
+export default function QuizPage() {
+  const router = useRouter();
+  const [questions, setQuestions] = useState<PersonalityQuestion[]>([]);
+  const [answers, setAnswers] = useState<(PersonalityType | null)[]>([]);
+  const [current, setCurrent] = useState(0);
+  const [result, setResult] = useState<PersonalityType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push("/login");
+      return;
+    }
+    getQuestions()
+      .then((qs) => {
+        setQuestions(qs);
+        setAnswers(new Array(qs.length).fill(null));
+      })
+      .catch(() => setError("質問の取得に失敗しました"))
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  function handleSelect(option: string) {
+    const type = extractType(option);
+    const next = [...answers];
+    next[current] = type;
+    setAnswers(next);
+
+    if (current < questions.length - 1) {
+      setCurrent((c) => c + 1);
+    }
+  }
+
+  async function handleSubmit() {
+    if (answers.some((a) => a === null)) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const { personality_type } = await saveResult(
+        answers as PersonalityType[]
+      );
+      setResult(personality_type);
+    } catch {
+      setError("診断結果の保存に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </main>
+    );
+  }
+
+  if (result) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="w-full max-w-md bg-white rounded-2xl shadow p-8 text-center">
+          <p className="text-sm text-gray-500 mb-2">あなたの性格タイプ</p>
+          <h2 className="text-3xl font-bold text-blue-600 mb-4">
+            {PERSONALITY_LABELS[result]}
+          </h2>
+          <p className="text-gray-600 mb-8">
+            診断が完了しました。あなたに合ったナッジでサポートします！
+          </p>
+          <button
+            onClick={() => router.push("/")}
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors"
+          >
+            はじめる
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  const q = questions[current];
+  const answered = answers.filter((a) => a !== null).length;
+  const allAnswered = answered === questions.length;
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-lg bg-white rounded-2xl shadow p-8">
+        <div className="mb-6">
+          <div className="flex justify-between text-sm text-gray-500 mb-2">
+            <span>性格診断</span>
+            <span>
+              {answered} / {questions.length}
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-blue-600 h-2 rounded-full transition-all"
+              style={{ width: `${(answered / questions.length) * 100}%` }}
+            />
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <h2 className="text-lg font-semibold text-gray-800 mb-6">
+          Q{current + 1}. {q.question}
+        </h2>
+
+        <div className="space-y-3 mb-8">
+          {q.options.map((option) => {
+            const type = extractType(option);
+            const label = option.replace(/（\w+）$/, "").trim();
+            const selected = answers[current] === type;
+            return (
+              <button
+                key={option}
+                onClick={() => handleSelect(option)}
+                className={`w-full text-left px-4 py-3 rounded-lg border-2 transition-colors ${
+                  selected
+                    ? "border-blue-500 bg-blue-50 text-blue-700"
+                    : "border-gray-200 hover:border-blue-300 text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex gap-3">
+          {current > 0 && (
+            <button
+              onClick={() => setCurrent((c) => c - 1)}
+              className="flex-1 py-2 px-4 border border-gray-300 text-gray-600 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              前へ
+            </button>
+          )}
+          {current < questions.length - 1 ? (
+            <button
+              onClick={() => setCurrent((c) => c + 1)}
+              disabled={answers[current] === null}
+              className="flex-1 py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-semibold rounded-lg transition-colors"
+            >
+              次へ
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={!allAnswered || submitting}
+              className="flex-1 py-2 px-4 bg-green-600 hover:bg-green-700 disabled:bg-green-300 text-white font-semibold rounded-lg transition-colors"
+            >
+              {submitting ? "診断中..." : "診断結果を見る"}
+            </button>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/lib/personality.ts
+++ b/frontend/src/lib/personality.ts
@@ -1,0 +1,17 @@
+import api from "./api";
+import type { PersonalityQuestion, PersonalityType } from "@/types";
+
+export async function getQuestions(): Promise<PersonalityQuestion[]> {
+  const res = await api.get<PersonalityQuestion[]>("/personality/questions");
+  return res.data;
+}
+
+export async function saveResult(
+  answers: PersonalityType[]
+): Promise<{ personality_type: PersonalityType }> {
+  const res = await api.post<{ personality_type: PersonalityType }>(
+    "/personality/result",
+    { answers }
+  );
+  return res.data;
+}

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -1,0 +1,7 @@
+import api from "./api";
+import type { User } from "@/types";
+
+export async function getMe(): Promise<User> {
+  const res = await api.get<User>("/users/me");
+  return res.data;
+}


### PR DESCRIPTION
## 概要

Issue #2「性格診断機能実装」を実装します。

## 変更内容

### バックエンド

| ファイル | 内容 |
|---|---|
| `internal/repository/personality.go` | 質問一覧取得・性格タイプ保存・シード投入 |
| `internal/service/personality.go` | 回答集計ロジック（同数は analytical 優先）・起動時自動シード（6問） |
| `internal/handler/personality.go` | `GET /api/v1/personality/questions`・`POST /api/v1/personality/result` |
| `internal/handler/user.go` | `GET /api/v1/users/me` を実装（personality_type 含む） |
| `main.go` | PersonalityRepository/Service/Handler・UserHandler を DI 接続 |

### フロントエンド

| ファイル | 内容 |
|---|---|
| `src/lib/personality.ts` | getQuestions / saveResult API 関数 |
| `src/lib/user.ts` | getMe API 関数 |
| `src/app/quiz/page.tsx` | 1問ずつ表示・プログレスバー・前後ナビ・診断結果画面 |
| `src/app/login/page.tsx` | ログイン後に `getMe` で personality_type をチェックし `/quiz` or `/dashboard` へ振り分け |

### 性格タイプ判定ロジック

各選択肢の末尾に `（analytical）` 等のタグを埋め込み、回答を集計して最多タイプを決定。同数の場合は `analytical > spontaneous > empathetic > competitive` の優先順で解決。

## テスト手順

- [x] バックエンド起動時に personality_questions テーブルへ6問が自動投入される
- [x] `GET /api/v1/personality/questions` で質問一覧が取得できる（JWT必須）
- [x] `POST /api/v1/personality/result` に `{"answers":["analytical","spontaneous",...]}` を送ると性格タイプが返る
- [x] `GET /api/v1/users/me` でユーザー情報（personality_type含む）が返る
- [x] 新規登録→ログイン後、/quiz へリダイレクトされる
- [x] 診断完了後、/ へ遷移する
- [x] 診断済みユーザーがログインすると /dashboard へリダイレクトされる

Closes #2