### PR TITLE
feat(history): 決定履歴保存・閲覧機能と後悔フィードバック機能を実装

### DIFF
--- a/backend/internal/handler/decision.go
+++ b/backend/internal/handler/decision.go
@@ -87,6 +87,25 @@ func (h *DecisionHandler) Get(c echo.Context) error {
 	return c.JSON(http.StatusOK, decision)
 }
 
+type updateRegretRequest struct {
+	Regret bool `json:"regret"`
+}
+
 func (h *DecisionHandler) UpdateRegret(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
+	userID := c.Get("userID").(uint)
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	var req updateRegretRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	decision, err := h.svc.UpdateRegret(uint(id), userID, req.Regret)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "decision not found")
+	}
+	return c.JSON(http.StatusOK, decision)
 }

--- a/backend/internal/repository/decision.go
+++ b/backend/internal/repository/decision.go
@@ -31,3 +31,16 @@ func (r *DecisionRepository) FindByIDAndUserID(id, userID uint) (*model.Decision
 	}
 	return &d, nil
 }
+
+func (r *DecisionRepository) UpdateRegret(id, userID uint, regret bool) error {
+	result := r.db.Model(&model.Decision{}).
+		Where("id = ? AND user_id = ?", id, userID).
+		Update("regret", regret)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/backend/internal/service/decision.go
+++ b/backend/internal/service/decision.go
@@ -96,6 +96,13 @@ func (s *DecisionService) Get(id, userID uint) (*model.Decision, error) {
 	return s.repo.FindByIDAndUserID(id, userID)
 }
 
+func (s *DecisionService) UpdateRegret(id, userID uint, regret bool) (*model.Decision, error) {
+	if err := s.repo.UpdateRegret(id, userID, regret); err != nil {
+		return nil, err
+	}
+	return s.repo.FindByIDAndUserID(id, userID)
+}
+
 func (s *DecisionService) callClaude(question string, options []string, character, personalityType string) (string, string, error) {
 	systemPrompt := buildSystemPrompt(character, personalityType)
 	userMsg := buildUserMessage(question, options)

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -86,6 +86,12 @@ export default function DashboardPage() {
         <div className="flex items-center gap-4">
           {user && <span className="text-sm text-gray-500">{user.email}</span>}
           <button
+            onClick={() => router.push("/history")}
+            className="text-sm text-gray-500 hover:text-gray-700"
+          >
+            履歴
+          </button>
+          <button
             onClick={() => { clearToken(); router.push("/login"); }}
             className="text-sm text-gray-500 hover:text-gray-700"
           >

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getToken, clearToken } from "@/lib/auth";
+import { getDecisions, updateRegret } from "@/lib/decision";
+import type { Decision } from "@/types";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ja-JP", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function HistoryCard({
+  decision,
+  onRegretUpdate,
+}: {
+  decision: Decision;
+  onRegretUpdate: (id: number, regret: boolean) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+
+  async function handleRegret(regret: boolean) {
+    setLoading(true);
+    try {
+      await updateRegret(decision.id, regret);
+      onRegretUpdate(decision.id, regret);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-5 space-y-3">
+      <div className="flex justify-between items-start">
+        <p className="font-semibold text-gray-800 flex-1 pr-4">{decision.question}</p>
+        <span className="text-xs text-gray-400 whitespace-nowrap">{formatDate(decision.created_at)}</span>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {decision.options.map((opt, i) => (
+          <span
+            key={i}
+            className={`px-3 py-1 rounded-full text-sm ${
+              opt === decision.ai_choice
+                ? "bg-blue-100 text-blue-700 font-semibold"
+                : "bg-gray-100 text-gray-500"
+            }`}
+          >
+            {opt}
+          </span>
+        ))}
+      </div>
+
+      <div className="bg-gray-50 rounded-xl p-3 text-sm text-gray-600">
+        <span className="font-medium text-blue-600">AI の選択: </span>
+        {decision.ai_choice}
+        {decision.ai_reason && (
+          <p className="mt-1 text-gray-500 text-xs">{decision.ai_reason}</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 pt-1">
+        <span className="text-sm text-gray-500">結果は？</span>
+        <button
+          onClick={() => handleRegret(false)}
+          disabled={loading}
+          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
+            decision.regret === false
+              ? "bg-green-500 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-green-50 hover:text-green-700"
+          }`}
+        >
+          後悔なし
+        </button>
+        <button
+          onClick={() => handleRegret(true)}
+          disabled={loading}
+          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
+            decision.regret === true
+              ? "bg-red-500 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-red-50 hover:text-red-700"
+          }`}
+        >
+          後悔した
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function HistoryPage() {
+  const router = useRouter();
+  const [decisions, setDecisions] = useState<Decision[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!getToken()) { router.push("/login"); return; }
+    getDecisions()
+      .then(setDecisions)
+      .catch(() => setError("履歴の取得に失敗しました"))
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  function handleRegretUpdate(id: number, regret: boolean) {
+    setDecisions((prev) =>
+      prev.map((d) => (d.id === id ? { ...d, regret } : d))
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 px-4 py-3 flex justify-between items-center">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="text-gray-500 hover:text-gray-700 text-sm"
+          >
+            ← 戻る
+          </button>
+          <h1 className="text-xl font-bold text-gray-800">決定履歴</h1>
+        </div>
+        <button
+          onClick={() => { clearToken(); router.push("/login"); }}
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
+          ログアウト
+        </button>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        {loading && (
+          <div className="text-center text-gray-400 py-16">読み込み中...</div>
+        )}
+
+        {error && (
+          <div className="p-4 bg-red-50 border border-red-200 text-red-600 rounded-xl text-sm">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && decisions.length === 0 && (
+          <div className="text-center text-gray-400 py-16">
+            <p className="text-4xl mb-4">📋</p>
+            <p>まだ決定履歴がありません</p>
+            <button
+              onClick={() => router.push("/dashboard")}
+              className="mt-4 text-sm text-blue-600 hover:underline"
+            >
+              AIに決めてもらう →
+            </button>
+          </div>
+        )}
+
+        {!loading && decisions.length > 0 && (
+          <div className="space-y-4">
+            {decisions.map((d) => (
+              <HistoryCard key={d.id} decision={d} onRegretUpdate={handleRegretUpdate} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/lib/decision.ts
+++ b/frontend/src/lib/decision.ts
@@ -27,6 +27,11 @@ export async function getDecision(id: number): Promise<Decision> {
   return res.data;
 }
 
+export async function updateRegret(id: number, regret: boolean): Promise<Decision> {
+  const res = await api.patch<Decision>(`/decisions/${id}/regret`, { regret });
+  return res.data;
+}
+
 export async function updateCharacter(character: AICharacter): Promise<void> {
   await api.patch("/users/me/character", { character });
 }


### PR DESCRIPTION
## 概要

Issue #6 の実装。決定履歴一覧ページと後悔フィードバック機能を追加。

Closes #6

## 変更内容

### バックエンド
- `PATCH /api/v1/decisions/:id/regret` を実装
  - `repository`: `UpdateRegret` メソッドを追加（対象レコードの `regret` フィールドを更新）
  - `service`: `UpdateRegret` メソッドを追加（更新後のDecisionを返す）
  - `handler`: `UpdateRegret` を実装（`{"regret": bool}` を受け取り更新済みDecisionを返す）

### フロントエンド
- `/history` ページを新規作成
  - ログイン済みユーザーの決定履歴一覧を表示
  - 各履歴カードに「後悔なし」「後悔した」フィードバックボタンを配置
  - ボタンタップで `PATCH /api/v1/decisions/:id/regret` を呼び出し、UI をリアルタイム更新
- `lib/decision.ts` に `updateRegret` 関数を追加
- ダッシュボードのヘッダーに「履歴」リンクを追加

## テスト手順

- [x] `/history` にアクセスし、履歴一覧が表示されること
- [x] 「後悔なし」「後悔した」ボタンが正しく色変更されること
- [x] ページリロード後もフィードバック状態が保持されること
- [x] 未ログイン状態で `/history` にアクセスするとログイン画面にリダイレクトされること
- [x] バックエンド: `PATCH /api/v1/decisions/:id/regret` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)