### PR TITLE
docs: READMEに本番URLとスクリーンショット欄を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 # Go
 backend/tmp/
 backend/nudge-me
+backend/nudge-me-server-linux
 *.exe
 
 # SQLite

--- a/README.md
+++ b/README.md
@@ -98,9 +98,32 @@ npm run dev
 
 ---
 
+## 本番環境
+
+**URL:** http://52.193.6.70
+
+| ページ | URL |
+|--------|-----|
+| ランディング | http://52.193.6.70/ |
+| 新規登録 | http://52.193.6.70/register |
+| ログイン | http://52.193.6.70/login |
+| ダッシュボード | http://52.193.6.70/dashboard |
+| 決断履歴 | http://52.193.6.70/history |
+
+---
+
 ## スクリーンショット
 
-*（Coming soon）*
+### ランディングページ
+![ランディングページ](docs/screenshots/landing.png)
+
+### ダッシュボード（AI決断）
+![ダッシュボード](docs/screenshots/dashboard.png)
+
+### 決断履歴
+![決断履歴](docs/screenshots/history.png)
+
+> スクリーンショットは `docs/screenshots/` に配置してください。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #20 に対応し、本番デプロイ完了に伴いREADMEを更新。

## 変更内容

- 本番環境セクションを追加（URL一覧）
- スクリーンショット欄を整備（`docs/screenshots/` ディレクトリ作成）

## スクリーンショット追加手順

本番サイト http://52.193.6.70 をブラウザで開き、各ページのスクリーンショットを以下に配置してください:

- `docs/screenshots/landing.png`
- `docs/screenshots/dashboard.png`
- `docs/screenshots/history.png`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)