### PR TITLE
feat(backend,frontend): みんなの統計表示・Xシェア機能を実装 (#8, #11)

### DIFF
--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -4,13 +4,55 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/takatoseki0107/nudge-me/backend/internal/repository"
 )
 
-// StatsHandler handles statistics endpoints
-type StatsHandler struct{}
+type StatsHandler struct {
+	decisionRepo *repository.DecisionRepository
+}
 
-func NewStatsHandler() *StatsHandler { return &StatsHandler{} }
+func NewStatsHandler(decisionRepo *repository.DecisionRepository) *StatsHandler {
+	return &StatsHandler{decisionRepo: decisionRepo}
+}
+
+type optionStat struct {
+	Option  string  `json:"option"`
+	Count   int     `json:"count"`
+	Percent float64 `json:"percent"`
+}
 
 func (h *StatsHandler) GetOptionStats(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
+	question := c.QueryParam("question")
+	if question == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "question is required")
+	}
+	options := c.QueryParams()["options[]"]
+	if len(options) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "options[] is required")
+	}
+
+	counts, err := h.decisionRepo.CountByOption(question, options)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch stats")
+	}
+
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+
+	stats := make([]optionStat, 0, len(options))
+	for _, opt := range options {
+		cnt := counts[opt]
+		pct := 0.0
+		if total > 0 {
+			pct = float64(cnt) / float64(total) * 100
+		}
+		stats = append(stats, optionStat{Option: opt, Count: cnt, Percent: pct})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"total": total,
+		"stats": stats,
+	})
 }

--- a/backend/internal/repository/decision.go
+++ b/backend/internal/repository/decision.go
@@ -44,3 +44,27 @@ func (r *DecisionRepository) UpdateRegret(id, userID uint, regret bool) error {
 	}
 	return nil
 }
+
+func (r *DecisionRepository) CountByOption(question string, options []string) (map[string]int, error) {
+	type row struct {
+		AIChoice string
+		Count    int
+	}
+	var rows []row
+	err := r.db.Model(&model.Decision{}).
+		Select("ai_choice, count(*) as count").
+		Where("question = ? AND ai_choice IN ?", question, options).
+		Group("ai_choice").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int, len(options))
+	for _, o := range options {
+		counts[o] = 0
+	}
+	for _, row := range rows {
+		counts[row.AIChoice] = row.Count
+	}
+	return counts, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -60,7 +60,7 @@ func main() {
 	personalityHandler := handler.NewPersonalityHandler(personalitySvc)
 	decisionHandler := handler.NewDecisionHandler(decisionSvc)
 	userHandler := handler.NewUserHandler(userRepo)
-	statsHandler := handler.NewStatsHandler()
+	statsHandler := handler.NewStatsHandler(decisionRepo)
 
 	e := echo.New()
 	e.Use(middleware.Logger())

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -3,15 +3,50 @@
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { getToken } from "@/lib/auth";
-import { getDecision } from "@/lib/decision";
+import { getDecision, updateRegret, getOptionStats } from "@/lib/decision";
 import { getMe } from "@/lib/user";
 import type { Decision, AICharacter } from "@/types";
+import type { OptionStatsResponse } from "@/lib/decision";
 
 const CHARACTER_META: Record<string, { emoji: string; label: string; color: string }> = {
   harsh:  { emoji: "😈", label: "毒舌キャラ",     color: "text-red-600" },
   kind:   { emoji: "🌸", label: "優しいキャラ",   color: "text-pink-600" },
   sporty: { emoji: "🔥", label: "体育会系キャラ", color: "text-orange-500" },
 };
+
+function buildShareText(decision: Decision): string {
+  const reason = decision.ai_reason.slice(0, 50);
+  const suffix = decision.ai_reason.length > 50 ? "..." : "";
+  const text = `「${decision.question}」でNudgeMeに相談したら「${decision.ai_choice}」を勧められた！${reason}${suffix} #NudgeMe`;
+  return text.slice(0, 140);
+}
+
+function StatBar({ stats, total }: { stats: OptionStatsResponse; total: number }) {
+  if (total === 0) {
+    return (
+      <div className="text-xs text-gray-400 text-center py-2">まだ他のユーザーのデータがありません</div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {stats.stats.map((s) => (
+        <div key={s.option}>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-gray-700 font-medium truncate max-w-[70%]">{s.option}</span>
+            <span className="text-gray-400 shrink-0">{s.count}人 ({s.percent.toFixed(0)}%)</span>
+          </div>
+          <div className="w-full bg-gray-100 rounded-full h-2">
+            <div
+              className="bg-purple-400 h-2 rounded-full transition-all duration-500"
+              style={{ width: `${s.percent}%` }}
+            />
+          </div>
+        </div>
+      ))}
+      <p className="text-xs text-gray-400 text-right">合計 {total} 件の決断</p>
+    </div>
+  );
+}
 
 export default function DecisionResultPage() {
   const router = useRouter();
@@ -20,14 +55,39 @@ export default function DecisionResultPage() {
   const [character, setCharacter] = useState<AICharacter>("kind");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [stats, setStats] = useState<OptionStatsResponse | null>(null);
+  const [regretUpdating, setRegretUpdating] = useState(false);
 
   useEffect(() => {
     if (!getToken()) { router.push("/login"); return; }
     Promise.all([getDecision(Number(id)), getMe()])
-      .then(([d, u]) => { setDecision(d); setCharacter(u.ai_character); })
+      .then(([d, u]) => {
+        setDecision(d);
+        setCharacter(u.ai_character);
+        return getOptionStats(d.question, d.options);
+      })
+      .then((s) => setStats(s))
       .catch(() => setError("結果の取得に失敗しました"))
       .finally(() => setLoading(false));
   }, [id, router]);
+
+  async function handleRegret(regret: boolean) {
+    if (!decision) return;
+    setRegretUpdating(true);
+    try {
+      const updated = await updateRegret(decision.id, regret);
+      setDecision(updated);
+    } finally {
+      setRegretUpdating(false);
+    }
+  }
+
+  function handleShare() {
+    if (!decision) return;
+    const text = buildShareText(decision);
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
 
   if (loading) {
     return (
@@ -107,6 +167,48 @@ export default function DecisionResultPage() {
           <p className="text-gray-600 text-sm leading-relaxed whitespace-pre-wrap">{decision.ai_reason}</p>
         </div>
 
+        {/* みんなの統計 */}
+        {stats && (
+          <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-4">みんなはどっちを選んだ？</p>
+            <StatBar stats={stats} total={stats.total} />
+          </div>
+        )}
+
+        {/* 後悔フィードバック */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">この決断どうだった？</p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => handleRegret(false)}
+              disabled={regretUpdating}
+              className={`flex-1 py-3 rounded-xl text-sm font-semibold transition-all ${
+                decision.regret === false
+                  ? "bg-green-500 text-white shadow-sm"
+                  : "bg-gray-100 text-gray-600 hover:bg-green-50 hover:text-green-600"
+              }`}
+            >
+              ✓ 後悔なし
+            </button>
+            <button
+              onClick={() => handleRegret(true)}
+              disabled={regretUpdating}
+              className={`flex-1 py-3 rounded-xl text-sm font-semibold transition-all ${
+                decision.regret === true
+                  ? "bg-red-500 text-white shadow-sm"
+                  : "bg-gray-100 text-gray-600 hover:bg-red-50 hover:text-red-600"
+              }`}
+            >
+              😔 後悔した
+            </button>
+          </div>
+          {decision.regret !== null && (
+            <p className="text-xs text-gray-400 text-center mt-2">
+              {decision.regret ? "後悔したとフィードバック済み" : "後悔なしとフィードバック済み"}（変更可）
+            </p>
+          )}
+        </div>
+
         {/* アクション */}
         <div className="flex gap-3">
           <button
@@ -114,6 +216,13 @@ export default function DecisionResultPage() {
             className="flex-1 py-3.5 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl transition-colors shadow-md shadow-purple-100 text-sm"
           >
             別の悩みを相談する
+          </button>
+          <button
+            onClick={handleShare}
+            className="px-5 py-3.5 border-2 border-gray-200 hover:border-blue-300 hover:bg-blue-50 text-gray-500 font-semibold rounded-xl transition-colors text-sm"
+            title="Xでシェア"
+          >
+            𝕏
           </button>
           <button
             onClick={() => router.push("/history")}

--- a/frontend/src/lib/decision.ts
+++ b/frontend/src/lib/decision.ts
@@ -35,3 +35,22 @@ export async function updateRegret(id: number, regret: boolean): Promise<Decisio
 export async function updateCharacter(character: AICharacter): Promise<void> {
   await api.patch("/users/me/character", { character });
 }
+
+export interface OptionStat {
+  option: string;
+  count: number;
+  percent: number;
+}
+
+export interface OptionStatsResponse {
+  total: number;
+  stats: OptionStat[];
+}
+
+export async function getOptionStats(question: string, options: string[]): Promise<OptionStatsResponse> {
+  const params = new URLSearchParams();
+  params.append("question", question);
+  options.forEach((o) => params.append("options[]", o));
+  const res = await api.get<OptionStatsResponse>(`/stats/options?${params.toString()}`);
+  return res.data;
+}


### PR DESCRIPTION
## Summary

- `GET /api/v1/stats/options` を実装し、質問文ごとの選択肢選択数・割合を返す
- `DecisionRepository.CountByOption` でDBから集計
- 決断結果画面（/decisions/[id]）に統計バーを追加
- 決断結果画面に後悔フィードバックボタンを追加（#7の機能を結果画面でも操作可能に）
- 決断結果画面に「𝕏」シェアボタンを追加（Web Intent URL使用、140字以内に自動短縮）

Closes #8
Closes #11

## Test plan

- [x] 同じ質問で複数決断を作成して統計バーが正しく表示されることを確認
- [x] 統計がない場合（total=0）に「まだ他のユーザーのデータがありません」と表示されることを確認
- [x] Xシェアボタンを押すと新しいタブで共有ダイアログが開くことを確認
- [x] シェアテキストに悩み・選択・理由・#NudgeMeが含まれ140字以内であることを確認
- [x] 後悔フィードバックボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)