### PR TITLE
feat(backend,frontend): 性格タイプ再診断機能を実装 (#10)

### DIFF
--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -50,5 +50,26 @@ func (h *UserHandler) UpdateCharacter(c echo.Context) error {
 }
 
 func (h *UserHandler) UpdatePersonality(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{"message": "not implemented"})
+	userID := c.Get("userID").(uint)
+
+	var req struct {
+		PersonalityType string `json:"personality_type"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	allowed := map[string]bool{"analytical": true, "spontaneous": true, "empathetic": true, "competitive": true}
+	if !allowed[req.PersonalityType] {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid personality_type")
+	}
+
+	if err := h.userRepo.UpdatePersonality(userID, req.PersonalityType); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update personality")
+	}
+
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch user")
+	}
+	return c.JSON(http.StatusOK, user)
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -37,3 +37,8 @@ func (r *UserRepository) UpdateCharacter(userID uint, character string) error {
 	return r.db.Model(&model.User{}).Where("id = ?", userID).
 		Update("ai_character", character).Error
 }
+
+func (r *UserRepository) UpdatePersonality(userID uint, personalityType string) error {
+	return r.db.Model(&model.User{}).Where("id = ?", userID).
+		Update("personality_type", personalityType).Error
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -79,6 +79,9 @@ export default function DashboardPage() {
           <Link href="/history" className="text-sm text-gray-500 hover:text-purple-600 font-medium transition-colors">
             履歴
           </Link>
+          <Link href="/profile" className="text-sm text-gray-500 hover:text-purple-600 font-medium transition-colors">
+            プロフィール
+          </Link>
           <button
             onClick={() => { clearToken(); router.push("/login"); }}
             className="text-sm text-gray-400 hover:text-gray-600 transition-colors"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { getToken, clearToken } from "@/lib/auth";
+import { getMe } from "@/lib/user";
+import type { User, PersonalityType } from "@/types";
+
+const PERSONALITY_LABELS: Record<PersonalityType, { label: string; emoji: string }> = {
+  analytical:  { label: "分析タイプ",  emoji: "🔍" },
+  spontaneous: { label: "直感タイプ",  emoji: "⚡" },
+  empathetic:  { label: "共感タイプ",  emoji: "💜" },
+  competitive: { label: "競争タイプ",  emoji: "🏆" },
+};
+
+const CHARACTER_LABELS: Record<string, { label: string; emoji: string }> = {
+  harsh:  { label: "毒舌キャラ",     emoji: "😈" },
+  kind:   { label: "優しいキャラ",   emoji: "🌸" },
+  sporty: { label: "体育会系キャラ", emoji: "🔥" },
+};
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!getToken()) { router.push("/login"); return; }
+    getMe()
+      .then(setUser)
+      .catch(() => { clearToken(); router.push("/login"); })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-purple-300 border-t-purple-600 rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  const personality = user.personality_type ? PERSONALITY_LABELS[user.personality_type] : null;
+  const character = CHARACTER_LABELS[user.ai_character] ?? CHARACTER_LABELS["kind"];
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b border-gray-100 px-5 py-3 flex justify-between items-center sticky top-0 z-10">
+        <div className="flex items-center gap-3">
+          <Link href="/dashboard" className="text-gray-400 hover:text-purple-600 transition-colors text-sm">←</Link>
+          <span className="text-lg font-extrabold text-purple-700 tracking-tight">NudgeMe</span>
+          <span className="text-sm text-gray-400 font-medium">プロフィール</span>
+        </div>
+        <button
+          onClick={() => { clearToken(); router.push("/login"); }}
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          ログアウト
+        </button>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
+        {/* ユーザー情報 */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">アカウント</p>
+          <p className="text-gray-700 font-medium">{user.email}</p>
+          <p className="text-xs text-gray-400 mt-1">
+            登録日: {new Date(user.created_at).toLocaleDateString("ja-JP", { year: "numeric", month: "long", day: "numeric" })}
+          </p>
+        </div>
+
+        {/* 性格タイプ */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">性格タイプ</p>
+          {personality ? (
+            <div className="flex items-center gap-3 mb-4">
+              <span className="text-3xl">{personality.emoji}</span>
+              <div>
+                <p className="font-bold text-gray-800">{personality.label}</p>
+                <p className="text-xs text-gray-400">現在の診断結果</p>
+              </div>
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm mb-4">まだ診断していません</p>
+          )}
+          <button
+            onClick={() => router.push("/quiz?mode=retake")}
+            className="w-full py-3 border-2 border-purple-200 hover:border-purple-400 hover:bg-purple-50 text-purple-700 font-semibold rounded-xl transition-colors text-sm"
+          >
+            性格を再診断する
+          </button>
+        </div>
+
+        {/* AIキャラクター */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">使用中のAIキャラクター</p>
+          <div className="flex items-center gap-3">
+            <span className="text-3xl">{character.emoji}</span>
+            <div>
+              <p className="font-bold text-gray-800">{character.label}</p>
+              <p className="text-xs text-gray-400">ダッシュボードから変更できます</p>
+            </div>
+          </div>
+        </div>
+
+        {/* ナビゲーション */}
+        <div className="flex gap-3">
+          <Link
+            href="/dashboard"
+            className="flex-1 py-3 text-center bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl transition-colors text-sm"
+          >
+            ダッシュボードへ
+          </Link>
+          <Link
+            href="/history"
+            className="flex-1 py-3 text-center border-2 border-gray-200 hover:border-purple-300 hover:bg-purple-50 text-gray-500 font-semibold rounded-xl transition-colors text-sm"
+          >
+            決定履歴
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { getQuestions, saveResult } from "@/lib/personality";
+import { updatePersonality } from "@/lib/user";
 import { getToken } from "@/lib/auth";
 import type { PersonalityQuestion, PersonalityType } from "@/types";
 
@@ -20,6 +21,9 @@ function extractType(option: string): PersonalityType {
 
 export default function QuizPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isRetake = searchParams.get("mode") === "retake";
+
   const [questions, setQuestions] = useState<PersonalityQuestion[]>([]);
   const [answers, setAnswers] = useState<(PersonalityType | null)[]>([]);
   const [current, setCurrent] = useState(0);
@@ -54,7 +58,16 @@ export default function QuizPage() {
     setSubmitting(true);
     setError("");
     try {
-      const { personality_type } = await saveResult(answers as PersonalityType[]);
+      let personality_type: PersonalityType;
+      if (isRetake) {
+        const counts: Record<PersonalityType, number> = { analytical: 0, spontaneous: 0, empathetic: 0, competitive: 0 };
+        (answers as PersonalityType[]).forEach((a) => { counts[a]++; });
+        personality_type = (Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0]) as PersonalityType;
+        await updatePersonality(personality_type);
+      } else {
+        const res = await saveResult(answers as PersonalityType[]);
+        personality_type = res.personality_type;
+      }
       setResult(personality_type);
     } catch {
       setError("診断結果の保存に失敗しました");
@@ -84,10 +97,10 @@ export default function QuizPage() {
           <h2 className="text-3xl font-extrabold text-purple-700 mb-3">{r.label}</h2>
           <p className="text-gray-600 text-sm leading-relaxed mb-8">{r.desc}</p>
           <button
-            onClick={() => router.push("/dashboard")}
+            onClick={() => router.push(isRetake ? "/profile" : "/dashboard")}
             className="w-full py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl transition-colors shadow-md shadow-purple-200"
           >
-            はじめる →
+            {isRetake ? "プロフィールへ戻る →" : "はじめる →"}
           </button>
         </div>
       </main>
@@ -105,7 +118,7 @@ export default function QuizPage() {
         {/* ヘッダー */}
         <div className="text-center mb-6">
           <span className="text-xl font-extrabold text-purple-700 tracking-tight">NudgeMe</span>
-          <p className="text-sm text-gray-500 mt-0.5">性格診断</p>
+          <p className="text-sm text-gray-500 mt-0.5">{isRetake ? "性格再診断" : "性格診断"}</p>
         </div>
 
         <div className="bg-white rounded-2xl shadow-sm border border-purple-100 p-8">

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -1,7 +1,12 @@
 import api from "./api";
-import type { User } from "@/types";
+import type { User, PersonalityType } from "@/types";
 
 export async function getMe(): Promise<User> {
   const res = await api.get<User>("/users/me");
+  return res.data;
+}
+
+export async function updatePersonality(personalityType: PersonalityType): Promise<User> {
+  const res = await api.patch<User>("/users/me/personality", { personality_type: personalityType });
   return res.data;
 }


### PR DESCRIPTION
## Summary

- `PATCH /api/v1/users/me/personality` を実装し、性格タイプを更新できるように
- `UserRepository.UpdatePersonality` をリポジトリに追加
- `/profile` ページを新規作成（性格タイプ・AIキャラクター表示、再診断ボタン）
- `/quiz?mode=retake` で再診断できるよう分岐追加（戻り先を `/profile` に変更）
- ダッシュボードヘッダーにプロフィールリンクを追加

Closes #10

## Test plan

- [x] プロフィールページ（/profile）が正常に表示されることを確認
- [x] 「性格を再診断する」ボタンを押すと /quiz?mode=retake に遷移することを確認
- [x] 再診断完了後に「プロフィールへ戻る」ボタンで /profile に戻ることを確認
- [x] 再診断後に性格タイプが更新されていることを確認
- [x] 既存の決断履歴に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)