### PR TITLE
fix: harsh→sarcasticのキャラクターID修正漏れを解消

### DIFF
--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -33,9 +33,9 @@ func (h *UserHandler) UpdateCharacter(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
-	allowed := map[string]bool{"harsh": true, "kind": true, "sporty": true}
+	allowed := map[string]bool{"sarcastic": true, "kind": true, "sporty": true}
 	if !allowed[req.Character] {
-		return echo.NewHTTPError(http.StatusBadRequest, "character must be harsh, kind, or sporty")
+		return echo.NewHTTPError(http.StatusBadRequest, "character must be sarcastic, kind, or sporty")
 	}
 
 	if err := h.userRepo.UpdateCharacter(userID, req.Character); err != nil {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { createDecision, createRandomDecision, updateCharacter } from "@/lib/dec
 import type { AICharacter, User } from "@/types";
 
 const CHARACTERS: { value: AICharacter; label: string; emoji: string; desc: string }[] = [
-  { value: "harsh",  label: "毒舌",     emoji: "😈", desc: "ズバッと本音で押す" },
+  { value: "sarcastic",  label: "毒舌",     emoji: "😈", desc: "ズバッと本音で押す" },
   { value: "kind",   label: "優しい",   emoji: "🌸", desc: "温かく寄り添う" },
   { value: "sporty", label: "体育会系", emoji: "🔥", desc: "熱血全力で決める" },
 ];

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -9,7 +9,7 @@ import type { Decision, AICharacter } from "@/types";
 import type { OptionStatsResponse } from "@/lib/decision";
 
 const CHARACTER_META: Record<string, { emoji: string; label: string; color: string }> = {
-  harsh:  { emoji: "😈", label: "毒舌キャラ",     color: "text-red-600" },
+  sarcastic:  { emoji: "😈", label: "毒舌キャラ",     color: "text-red-600" },
   kind:   { emoji: "🌸", label: "優しいキャラ",   color: "text-pink-600" },
   sporty: { emoji: "🔥", label: "体育会系キャラ", color: "text-orange-500" },
 };

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -15,7 +15,7 @@ const PERSONALITY_LABELS: Record<PersonalityType, { label: string; emoji: string
 };
 
 const CHARACTER_LABELS: Record<string, { label: string; emoji: string }> = {
-  harsh:  { label: "毒舌キャラ",     emoji: "😈" },
+  sarcastic:  { label: "毒舌キャラ",     emoji: "😈" },
   kind:   { label: "優しいキャラ",   emoji: "🌸" },
   sporty: { label: "体育会系キャラ", emoji: "🔥" },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 export type PersonalityType = "analytical" | "spontaneous" | "empathetic" | "competitive";
-export type AICharacter = "harsh" | "kind" | "sporty";
+export type AICharacter = "sarcastic" | "kind" | "sporty";
 
 export interface User {
   id: number;


### PR DESCRIPTION
## 問題

本番環境でApplication errorが発生。キャラクターID `harsh` → `sarcastic` の変更がフロントエンドとバックエンドに未反映だった。

## 修正内容

- `frontend/src/types/index.ts`: AICharacter型 `"harsh"` → `"sarcastic"`
- `frontend/src/app/dashboard/page.tsx`: CHARACTERSのvalue `"harsh"` → `"sarcastic"`
- `frontend/src/app/decisions/[id]/page.tsx`: CHARACTER_METAのキー `harsh` → `sarcastic`
- `frontend/src/app/profile/page.tsx`: CHARACTER_LABELSのキー `harsh` → `sarcastic`
- `backend/internal/handler/user.go`: allowedマップを `"sarcastic"` に変更

## テスト計画

- [x] CI（バックエンド go vet + ビルド、フロントエンド lint/type-check/build）グリーン確認
- [x] デプロイ後に毒舌キャラクターでのAI決断が正常動作することを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)