### PR TITLE
fix: Next.js standaloneビルド後の静的ファイルコピー手順を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,8 @@ cd /opt/nudge-me/frontend
 git pull origin main
 npm install
 npm run build
+# standaloneモードでは静的ファイルを手動コピーする必要がある
+cp -r .next/static .next/standalone/.next/static
 sudo systemctl restart nudge-me-frontend
 ```
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -138,6 +138,8 @@ cd /opt/nudge-me/frontend
 git pull origin main
 npm install
 npm run build
+# standaloneモードでは静的ファイルを手動コピーする必要がある
+cp -r .next/static .next/standalone/.next/static
 sudo systemctl restart nudge-me-frontend
 ```
 
@@ -279,5 +281,5 @@ scp -i ~/.ssh/takatoseki.pem nudge-me-server ubuntu@52.193.6.70:/opt/nudge-me/ba
 ssh -i ~/.ssh/takatoseki.pem ubuntu@52.193.6.70 "sudo systemctl restart nudge-me-backend"
 
 # フロントエンド更新（EC2上で）
-cd /opt/nudge-me/frontend && git pull origin main && npm install && npm run build && sudo systemctl restart nudge-me-frontend
+cd /opt/nudge-me/frontend && git pull origin main && npm install && npm run build && cp -r .next/static .next/standalone/.next/static && sudo systemctl restart nudge-me-frontend
 ```


### PR DESCRIPTION
## 問題

本番環境でApplication errorが発生。`/_next/static/chunks/*.js` が404になっておりReactのハイドレーションが失敗していた。

## 原因

Next.js の `output: "standalone"` ビルドでは、`npm run build` 後に `.next/static` を `.next/standalone/.next/static` へ手動コピーしないと静的ファイルが配信されない。

## 修正

デプロイ手順と運用コマンド集に以下を追加:
```bash
cp -r .next/static .next/standalone/.next/static
```

対象ファイル:
- `docs/infrastructure.md`
- `CLAUDE.md`

## 本番での対処

EC2上で即時コピーして再起動済み。`/_next/static/` が200で返ることを確認。

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)