### PR TITLE
docs(readme): スクリーンショット欄をlanding/dashboard/resultの3枚構成に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,11 @@ npm run dev
 ### ランディングページ
 ![ランディングページ](docs/screenshots/landing.png)
 
-### ダッシュボード（AI決断）
+### ダッシュボード
 ![ダッシュボード](docs/screenshots/dashboard.png)
 
-### 決断履歴
-![決断履歴](docs/screenshots/history.png)
-
-> スクリーンショットは `docs/screenshots/` に配置してください。
+### AI決定結果
+![AI決定結果](docs/screenshots/result.png)
 
 ---
 


### PR DESCRIPTION
## 変更内容

- 「決断履歴（history.png）」→「AI決定結果（result.png）」に差し替え
- セクション名を「ダッシュボード（AI決断）」→「ダッシュボード」、「決断履歴」→「AI決定結果」に修正
- プレースホルダーコメント（`> スクリーンショットは...`）を削除

## 画像ファイルについて

`docs/screenshots/` に以下3枚を別途追加予定:
- `landing.png`
- `dashboard.png`
- `result.png`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)