### PR TITLE
docs: ドキュメントの不備を修正（api-spec/infrastructure/CLAUDE.md）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ npm run dev
 | `DB_PATH` | 任意 | SQLiteファイルパス（デフォルト: ./nudge.db） | `./nudge.db` |
 | `ANTHROPIC_API_KEY` | 必須 | Claude APIキー | `sk-ant-...` |
 | `FRONTEND_URL` | 必須 | フロントエンドURL（CORS用） | `http://localhost:3000` |
+| `NEXT_PUBLIC_API_URL` | 必須（本番） | フロントエンドからのAPIベースURL | `http://localhost:8080` |
 
 ---
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -39,6 +39,19 @@
 { "token": "eyJ...", "user": { "id": 1, "email": "user@example.com", ... } }
 ```
 
+#### POST /api/v1/auth/logout
+```json
+// Request
+// Authorization: Bearer <token>
+// Body: なし
+
+// Response 200
+{ "message": "ログアウトしました" }
+
+// Response 401（トークンなし or 無効）
+{ "message": "認証エラー" }
+```
+
 ---
 
 ### 性格診断（要認証）

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -79,6 +79,16 @@ sudo apt install -y nodejs
 node -v && npm -v
 ```
 
+### 4. Go のインストール
+
+```bash
+wget https://go.dev/dl/go1.22.0.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+source ~/.bashrc
+go version
+```
+
 ### 5. Nginx のインストール
 
 ```bash


### PR DESCRIPTION
## 概要

最終確認で発見されたドキュメントの不備3点を修正。

## 変更内容

- **api-spec.md**: `POST /api/v1/auth/logout` のリクエスト/レスポンス詳細を追加（他の認証エンドポイントと同様の形式で記載）
- **infrastructure.md**: EC2セットアップ手順のStep4（Go言語のインストール）が抜けていたため追記
- **CLAUDE.md**: 環境変数一覧に `NEXT_PUBLIC_API_URL`（本番環境で必須）を追加

## テスト計画

- [x] 各ドキュメントを通読して内容の整合性を確認
- [x] Step番号が1→2→3→4→5→6→7→8と連続していることを確認

Closes #37