### PR TITLE
feat(frontend): Lambda移行に伴うID型変更とAPIURL対応

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# API base URL
+# ローカル開発: http://localhost:8080
+# 本番 (API Gateway): https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com
+NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -60,7 +60,7 @@ export default function DecisionResultPage() {
 
   useEffect(() => {
     if (!getToken()) { router.push("/login"); return; }
-    Promise.all([getDecision(Number(id)), getMe()])
+    Promise.all([getDecision(id), getMe()])
       .then(([d, u]) => {
         setDecision(d);
         setCharacter(u.ai_character);

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -29,7 +29,7 @@ function HistoryCard({
   onRegretUpdate,
 }: {
   decision: Decision;
-  onRegretUpdate: (id: number, regret: boolean) => void;
+  onRegretUpdate: (id: string, regret: boolean) => void;
 }) {
   const [updating, setUpdating] = useState(false);
 
@@ -119,7 +119,7 @@ export default function HistoryPage() {
       .finally(() => setLoading(false));
   }, [router]);
 
-  function handleRegretUpdate(id: number, regret: boolean) {
+  function handleRegretUpdate(id: string, regret: boolean) {
     setDecisions((prev) => prev.map((d) => (d.id === id ? { ...d, regret } : d)));
   }
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import api from "./api";
 
 export interface AuthUser {
-  id: number;
+  id: string;
   email: string;
 }
 

--- a/frontend/src/lib/decision.ts
+++ b/frontend/src/lib/decision.ts
@@ -22,12 +22,12 @@ export async function getDecisions(): Promise<Decision[]> {
   return res.data;
 }
 
-export async function getDecision(id: number): Promise<Decision> {
+export async function getDecision(id: string): Promise<Decision> {
   const res = await api.get<Decision>(`/decisions/${id}`);
   return res.data;
 }
 
-export async function updateRegret(id: number, regret: boolean): Promise<Decision> {
+export async function updateRegret(id: string, regret: boolean): Promise<Decision> {
   const res = await api.patch<Decision>(`/decisions/${id}/regret`, { regret });
   return res.data;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,7 +2,7 @@ export type PersonalityType = "analytical" | "spontaneous" | "empathetic" | "com
 export type AICharacter = "sarcastic" | "kind" | "sporty";
 
 export interface User {
-  id: number;
+  id: string;
   email: string;
   personality_type: PersonalityType | null;
   ai_character: AICharacter;
@@ -10,8 +10,8 @@ export interface User {
 }
 
 export interface Decision {
-  id: number;
-  user_id: number;
+  id: string;
+  user_id: string;
   question: string;
   options: string[];
   ai_choice: string;
@@ -22,7 +22,7 @@ export interface Decision {
 }
 
 export interface PersonalityQuestion {
-  id: number;
+  id: string;
   question: string;
   options: string[];
 }


### PR DESCRIPTION
## 概要

バックエンドのLambda + DynamoDB移行（#39/#40）に伴い、フロントエンドのID型をすべて `string` に変更。

## 変更内容

- `types/index.ts`: `User.id`, `Decision.id`, `Decision.user_id`, `PersonalityQuestion.id` を `number` → `string`
- `lib/auth.ts`: `AuthUser.id` を `number` → `string`
- `lib/decision.ts`: `getDecision`・`updateRegret` の引数型を `number` → `string`
- `app/decisions/[id]/page.tsx`: `Number(id)` の変換を削除（URL paramはすでにstring）
- `app/history/page.tsx`: `handleRegretUpdate` / `onRegretUpdate` の id 型を `string` に統一
- `frontend/.env.example` を新規追加（`NEXT_PUBLIC_API_URL` の設定例）

## テスト計画

- [x] `npx tsc --noEmit` でエラーなし（確認済み）
- [x] ローカルでログイン・意思決定作成・履歴表示の動作確認
- [x] 本番は `NEXT_PUBLIC_API_URL` に API Gateway URL を設定して確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)