### PR TITLE
fix(backend): DynamoDBテーブル名を環境変数から取得・dynamodbavタグ追加

### DIFF
--- a/backend/internal/model/decision.go
+++ b/backend/internal/model/decision.go
@@ -3,13 +3,13 @@ package model
 import "time"
 
 type Decision struct {
-	ID        string    `json:"id"`
-	UserID    string    `json:"user_id"`
-	Question  string    `json:"question"`
-	Options   []string  `json:"options"`
-	AIChoice  string    `json:"ai_choice"`
-	AIReason  string    `json:"ai_reason"`
-	IsRandom  bool      `json:"is_random"`
-	Regret    *bool     `json:"regret"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string    `json:"id" dynamodbav:"id"`
+	UserID    string    `json:"user_id" dynamodbav:"user_id"`
+	Question  string    `json:"question" dynamodbav:"question"`
+	Options   []string  `json:"options" dynamodbav:"options"`
+	AIChoice  string    `json:"ai_choice" dynamodbav:"ai_choice"`
+	AIReason  string    `json:"ai_reason" dynamodbav:"ai_reason"`
+	IsRandom  bool      `json:"is_random" dynamodbav:"is_random"`
+	Regret    *bool     `json:"regret" dynamodbav:"regret"`
+	CreatedAt time.Time `json:"created_at" dynamodbav:"created_at"`
 }

--- a/backend/internal/model/personality_question.go
+++ b/backend/internal/model/personality_question.go
@@ -1,7 +1,7 @@
 package model
 
 type PersonalityQuestion struct {
-	ID       string   `json:"id"`
-	Question string   `json:"question"`
-	Options  []string `json:"options"`
+	ID       string   `json:"id" dynamodbav:"id"`
+	Question string   `json:"question" dynamodbav:"question"`
+	Options  []string `json:"options" dynamodbav:"options"`
 }

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -3,10 +3,10 @@ package model
 import "time"
 
 type User struct {
-	ID              string    `json:"id"`
-	Email           string    `json:"email"`
-	PasswordHash    string    `json:"-"`
-	PersonalityType string    `json:"personality_type"`
-	AICharacter     string    `json:"ai_character"`
-	CreatedAt       time.Time `json:"created_at"`
+	ID              string    `json:"id" dynamodbav:"id"`
+	Email           string    `json:"email" dynamodbav:"email"`
+	PasswordHash    string    `json:"-" dynamodbav:"password_hash"`
+	PersonalityType string    `json:"personality_type" dynamodbav:"personality_type"`
+	AICharacter     string    `json:"ai_character" dynamodbav:"ai_character"`
+	CreatedAt       time.Time `json:"created_at" dynamodbav:"created_at"`
 }

--- a/backend/internal/repository/decision_dynamo.go
+++ b/backend/internal/repository/decision_dynamo.go
@@ -12,14 +12,13 @@ import (
 	"github.com/takatoseki0107/nudge-me/backend/internal/model"
 )
 
-const decisionsTable = "nudge-me-decisions"
-
 type DecisionRepository struct {
-	db *dynamodb.Client
+	db    *dynamodb.Client
+	table string
 }
 
-func NewDecisionRepository(db *dynamodb.Client) *DecisionRepository {
-	return &DecisionRepository{db: db}
+func NewDecisionRepository(db *dynamodb.Client, table string) *DecisionRepository {
+	return &DecisionRepository{db: db, table: table}
 }
 
 func (r *DecisionRepository) Create(ctx context.Context, d *model.Decision) error {
@@ -32,7 +31,7 @@ func (r *DecisionRepository) Create(ctx context.Context, d *model.Decision) erro
 	}
 
 	_, err = r.db.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: aws.String(decisionsTable),
+		TableName: aws.String(r.table),
 		Item:      item,
 	})
 	return err
@@ -40,7 +39,7 @@ func (r *DecisionRepository) Create(ctx context.Context, d *model.Decision) erro
 
 func (r *DecisionRepository) FindByUserID(ctx context.Context, userID string) ([]model.Decision, error) {
 	out, err := r.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(decisionsTable),
+		TableName:              aws.String(r.table),
 		IndexName:              aws.String("user_id-created_at-index"),
 		KeyConditionExpression: aws.String("user_id = :uid"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -61,7 +60,7 @@ func (r *DecisionRepository) FindByUserID(ctx context.Context, userID string) ([
 
 func (r *DecisionRepository) FindByIDAndUserID(ctx context.Context, id, userID string) (*model.Decision, error) {
 	out, err := r.db.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(decisionsTable),
+		TableName: aws.String(r.table),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: id},
 		},
@@ -91,7 +90,7 @@ func (r *DecisionRepository) UpdateRegret(ctx context.Context, id, userID string
 	_ = existing
 
 	_, err = r.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(decisionsTable),
+		TableName: aws.String(r.table),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: id},
 		},
@@ -111,7 +110,7 @@ func (r *DecisionRepository) CountByOption(ctx context.Context, question string,
 
 	// Scan with filter — acceptable for stats endpoint (low-frequency call)
 	out, err := r.db.Scan(ctx, &dynamodb.ScanInput{
-		TableName:        aws.String(decisionsTable),
+		TableName:        aws.String(r.table),
 		FilterExpression: aws.String("#q = :q"),
 		ExpressionAttributeNames: map[string]string{
 			"#q": "question",

--- a/backend/internal/repository/personality_dynamo.go
+++ b/backend/internal/repository/personality_dynamo.go
@@ -11,19 +11,19 @@ import (
 	"github.com/takatoseki0107/nudge-me/backend/internal/model"
 )
 
-const personalityQuestionsTable = "nudge-me-personality-questions"
-
 type PersonalityRepository struct {
-	db *dynamodb.Client
+	db        *dynamodb.Client
+	table     string
+	usersTable string
 }
 
-func NewPersonalityRepository(db *dynamodb.Client) *PersonalityRepository {
-	return &PersonalityRepository{db: db}
+func NewPersonalityRepository(db *dynamodb.Client, table, usersTable string) *PersonalityRepository {
+	return &PersonalityRepository{db: db, table: table, usersTable: usersTable}
 }
 
 func (r *PersonalityRepository) FindAllQuestions(ctx context.Context) ([]model.PersonalityQuestion, error) {
 	out, err := r.db.Scan(ctx, &dynamodb.ScanInput{
-		TableName: aws.String(personalityQuestionsTable),
+		TableName: aws.String(r.table),
 	})
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (r *PersonalityRepository) FindAllQuestions(ctx context.Context) ([]model.P
 
 func (r *PersonalityRepository) CountQuestions(ctx context.Context) (int64, error) {
 	out, err := r.db.DescribeTable(ctx, &dynamodb.DescribeTableInput{
-		TableName: aws.String(personalityQuestionsTable),
+		TableName: aws.String(r.table),
 	})
 	if err != nil {
 		return 0, err
@@ -56,7 +56,7 @@ func (r *PersonalityRepository) SeedQuestions(ctx context.Context, questions []m
 			return err
 		}
 		_, err = r.db.PutItem(ctx, &dynamodb.PutItemInput{
-			TableName: aws.String(personalityQuestionsTable),
+			TableName: aws.String(r.table),
 			Item:      item,
 		})
 		if err != nil {
@@ -68,7 +68,7 @@ func (r *PersonalityRepository) SeedQuestions(ctx context.Context, questions []m
 
 func (r *PersonalityRepository) UpdatePersonalityType(ctx context.Context, userID, personalityType string) error {
 	_, err := r.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(usersTable),
+		TableName: aws.String(r.usersTable),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: userID},
 		},

--- a/backend/internal/repository/user_dynamo.go
+++ b/backend/internal/repository/user_dynamo.go
@@ -12,14 +12,13 @@ import (
 	"github.com/takatoseki0107/nudge-me/backend/internal/model"
 )
 
-const usersTable = "nudge-me-users"
-
 type UserRepository struct {
-	db *dynamodb.Client
+	db    *dynamodb.Client
+	table string
 }
 
-func NewUserRepository(db *dynamodb.Client) *UserRepository {
-	return &UserRepository{db: db}
+func NewUserRepository(db *dynamodb.Client, table string) *UserRepository {
+	return &UserRepository{db: db, table: table}
 }
 
 func (r *UserRepository) Create(ctx context.Context, user *model.User) error {
@@ -35,7 +34,7 @@ func (r *UserRepository) Create(ctx context.Context, user *model.User) error {
 	}
 
 	_, err = r.db.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName:           aws.String(usersTable),
+		TableName:           aws.String(r.table),
 		Item:                item,
 		ConditionExpression: aws.String("attribute_not_exists(id)"),
 	})
@@ -44,7 +43,7 @@ func (r *UserRepository) Create(ctx context.Context, user *model.User) error {
 
 func (r *UserRepository) FindByEmail(ctx context.Context, email string) (*model.User, error) {
 	out, err := r.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(usersTable),
+		TableName:              aws.String(r.table),
 		IndexName:              aws.String("email-index"),
 		KeyConditionExpression: aws.String("email = :email"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -68,7 +67,7 @@ func (r *UserRepository) FindByEmail(ctx context.Context, email string) (*model.
 
 func (r *UserRepository) FindByID(ctx context.Context, id string) (*model.User, error) {
 	out, err := r.db.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(usersTable),
+		TableName: aws.String(r.table),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: id},
 		},
@@ -89,7 +88,7 @@ func (r *UserRepository) FindByID(ctx context.Context, id string) (*model.User, 
 
 func (r *UserRepository) UpdateCharacter(ctx context.Context, userID, character string) error {
 	_, err := r.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(usersTable),
+		TableName: aws.String(r.table),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: userID},
 		},
@@ -103,7 +102,7 @@ func (r *UserRepository) UpdateCharacter(ctx context.Context, userID, character 
 
 func (r *UserRepository) UpdatePersonality(ctx context.Context, userID, personalityType string) error {
 	_, err := r.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
-		TableName: aws.String(usersTable),
+		TableName: aws.String(r.table),
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: userID},
 		},

--- a/backend/lambda/main.go
+++ b/backend/lambda/main.go
@@ -26,16 +26,20 @@ func main() {
 
 	jwtSecret := mustEnv("JWT_SECRET")
 
-	userRepo := repository.NewUserRepository(db)
+	usersTable := mustEnv("DYNAMO_USERS_TABLE")
+	decisionsTable := mustEnv("DYNAMO_DECISIONS_TABLE")
+	personalityTable := mustEnv("DYNAMO_PERSONALITY_TABLE")
+
+	userRepo := repository.NewUserRepository(db, usersTable)
 	authSvc := service.NewAuthService(userRepo, jwtSecret)
 
-	personalityRepo := repository.NewPersonalityRepository(db)
+	personalityRepo := repository.NewPersonalityRepository(db, personalityTable, usersTable)
 	personalitySvc := service.NewPersonalityService(personalityRepo)
 	if err := personalitySvc.SeedIfEmpty(ctx); err != nil {
 		log.Fatalf("failed to seed personality questions: %v", err)
 	}
 
-	decisionRepo := repository.NewDecisionRepository(db)
+	decisionRepo := repository.NewDecisionRepository(db, decisionsTable)
 	decisionSvc := service.NewDecisionService(decisionRepo, userRepo, mustEnv("ANTHROPIC_API_KEY"))
 
 	authHandler := handler.NewAuthHandler(authSvc)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -164,9 +164,12 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
-      JWT_SECRET        = var.jwt_secret
-      ANTHROPIC_API_KEY = var.anthropic_api_key
-      FRONTEND_URL      = var.frontend_url
+      JWT_SECRET              = var.jwt_secret
+      ANTHROPIC_API_KEY       = var.anthropic_api_key
+      FRONTEND_URL            = var.frontend_url
+      DYNAMO_USERS_TABLE      = aws_dynamodb_table.users.name
+      DYNAMO_DECISIONS_TABLE  = aws_dynamodb_table.decisions.name
+      DYNAMO_PERSONALITY_TABLE = aws_dynamodb_table.personality_questions.name
     }
   }
 


### PR DESCRIPTION
## 原因

repository層のテーブル名が `nudge-me-users` 等ハードコードされており、Terraformが作成した `nudge-me-prod-users` と一致せず Lambda が AccessDenied で起動失敗していた。

また `attributevalue.MarshalMap` は `dynamodbav` タグを参照するが、モデルに `json` タグしかなかったため `id` フィールドが DynamoDB に書き込まれず ValidationException が発生していた。

## 修正内容

- `NewUserRepository` / `NewDecisionRepository` / `NewPersonalityRepository` がテーブル名を引数で受け取る方式に変更
- `lambda/main.go` で `DYNAMO_USERS_TABLE` / `DYNAMO_DECISIONS_TABLE` / `DYNAMO_PERSONALITY_TABLE` 環境変数からテーブル名を取得
- `terraform/main.tf` のLambda環境変数にテーブル名を追加
- 全モデル（User / Decision / PersonalityQuestion）に `dynamodbav` タグを追加

## 動作確認済み

- `POST /api/v1/auth/register` → 200 OK（UUID採番確認）
- `POST /api/v1/auth/login` → JWT取得確認
- `GET /api/v1/personality/questions` → 6件取得確認

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)