### PR TITLE
feat(frontend): AWS AmplifyへのSSR移行設定を追加

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,19 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - cd frontend
+        - npm ci
+    build:
+      commands:
+        - cd frontend
+        - npm run build
+  artifacts:
+    baseDirectory: frontend/.next
+    files:
+      - "**/*"
+  cache:
+    paths:
+      - frontend/node_modules/**/*
+      - frontend/.next/cache/**/*

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 # API base URL
 # ローカル開発: http://localhost:8080
-# 本番 (API Gateway): https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com
+# 本番 (API Gateway): https://40ywx4zpy8.execute-api.ap-northeast-1.amazonaws.com
 NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "standalone",
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## 概要
- `next.config.ts` から `output: "standalone"` を削除（AmplifyのSSRモードと非互換）
- `amplify.yml` を追加（Amplifyビルド・デプロイ設定）
- `frontend/.env.example` のAPI Gateway URL例を実際のURLに更新

## 変更内容

### next.config.ts
- `output: "standalone"` を削除。AmplifyはNext.jsのSSRを標準でサポートするためstandaloneモードは不要かつ非互換

### amplify.yml
- Amplifyのビルド設定ファイルを追加
- `frontend/` ディレクトリでの `npm ci` + `npm run build` を定義
- `node_modules` と `.next/cache` をキャッシュして再ビルドを高速化

### .env.example
- 本番API GatewayのURLコメントを実際のURL (`https://40ywx4zpy8.execute-api.ap-northeast-1.amazonaws.com`) に更新

## Amplifyコンソールでの設定手順（マージ後）
1. AWSコンソール → Amplify → 新しいアプリを作成
2. GitHubリポジトリを接続 → ブランチ: `main`
3. 環境変数を設定:
   - `NEXT_PUBLIC_API_URL` = `https://40ywx4zpy8.execute-api.ap-northeast-1.amazonaws.com`
4. デプロイ確認後、EC2のnginxプロキシ設定を削除 → EC2停止

## テスト計画
- [ ] ローカルで `npm run build` が通ること（standaloneなし）
- [ ] AmplifyでデプロイしてUIが正常に動作すること
- [ ] API Gateway経由でバックエンドと疎通できること

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)