### PR TITLE
fix(frontend): amplify.ymlのbuildフェーズのcdコマンドを修正

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,12 +3,10 @@ frontend:
   phases:
     preBuild:
       commands:
-        - cd frontend
-        - npm ci
+        - cd frontend && npm ci
     build:
       commands:
-        - cd frontend
-        - npm run build
+        - cd frontend && npm run build
   artifacts:
     baseDirectory: frontend/.next
     files:


### PR DESCRIPTION
## 概要
amplify.ymlの各フェーズが独立したシェルセッションで実行されるため、preBuildの `cd frontend` がbuildフェーズに引き継がれずビルド失敗していた問題を修正。

## エラー内容
```
cd: frontend: No such file or directory
!!! Build failed
```

## 修正内容
各フェーズのコマンドを `cd frontend && <command>` の形式で1行にまとめ、フェーズをまたいでディレクトリ状態に依存しないよう修正。

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)