### PR TITLE
fix(frontend): amplify.ymlのbuildフェーズの不要なcdを削除

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - cd frontend && npm ci
     build:
       commands:
-        - cd frontend && npm run build
+        - npm run build
   artifacts:
     baseDirectory: frontend/.next
     files:


### PR DESCRIPTION
## 概要
preBuildの `cd frontend` がbuildフェーズにも引き継がれるため、buildフェーズで再度 `cd frontend` しようとして失敗していた問題を修正。

## エラー内容
```
cd: frontend: No such file or directory
!!! Build failed
```

## 修正内容
buildフェーズの `cd frontend &&` を削除し `npm run build` のみにした。

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)