### PR TITLE
fix(frontend): amplify.ymlにappRoot設定を追加しSSRビルドを修正

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,17 +1,18 @@
 version: 1
+appRoot: frontend
 frontend:
   phases:
     preBuild:
       commands:
-        - cd frontend && npm ci
+        - npm ci
     build:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: frontend/.next
+    baseDirectory: .next
     files:
       - "**/*"
   cache:
     paths:
-      - frontend/node_modules/**/*
-      - frontend/.next/cache/**/*
+      - node_modules/**/*
+      - .next/cache/**/*


### PR DESCRIPTION
## 概要
AmplifyのWEB_COMPUTEモードで `deploy-manifest.json` が見つからずデプロイ失敗していた問題を修正。

## 原因
monorepo構成（Next.jsが `frontend/` サブディレクトリ）の場合、`appRoot: frontend` の指定と `baseDirectory: .next`（サブディレクトリ起点）の指定が必要だった。

## 修正内容
- `appRoot: frontend` を追加（AmplifyがNext.jsアプリのルートを正しく認識）
- `baseDirectory` を `frontend/.next` → `.next` に変更（appRoot起点の相対パスに統一）
- `preBuild`/`build` コマンドから `cd frontend` を削除（appRootで自動的に移動）
- キャッシュパスも `node_modules/**/*` に修正

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)