### PR TITLE
fix(frontend): Amplify用.amplify-hosting生成スクリプトを追加

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,18 +1,18 @@
 version: 1
-appRoot: frontend
 frontend:
   phases:
     preBuild:
       commands:
-        - npm ci
+        - cd frontend && npm ci
     build:
       commands:
         - npm run build
+        - bash scripts/build-amplify.sh
   artifacts:
-    baseDirectory: .next
+    baseDirectory: frontend/.amplify-hosting
     files:
       - "**/*"
   cache:
     paths:
-      - node_modules/**/*
-      - .next/cache/**/*
+      - frontend/node_modules/**/*
+      - frontend/.next/cache/**/*

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   async rewrites() {
     return [
       {

--- a/frontend/scripts/build-amplify.sh
+++ b/frontend/scripts/build-amplify.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# standaloneビルド出力からAmplify Hosting用の.amplify-hosting構造を生成する
+
+NEXT_DIR=".next"
+STANDALONE_DIR=".next/standalone"
+STATIC_DIR=".next/static"
+OUTPUT_DIR=".amplify-hosting"
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/compute/default"
+mkdir -p "$OUTPUT_DIR/static/_next/static"
+
+# standaloneサーバーをcompute/defaultにコピー
+cp -r "$STANDALONE_DIR/." "$OUTPUT_DIR/compute/default/"
+
+# 静的ファイルをstaticにコピー
+cp -r "$STATIC_DIR/." "$OUTPUT_DIR/static/_next/static/"
+
+# publicディレクトリがあればコピー
+if [ -d "public" ]; then
+  cp -r public/. "$OUTPUT_DIR/static/"
+fi
+
+# deploy-manifest.json を生成
+cat > "$OUTPUT_DIR/deploy-manifest.json" <<EOF
+{
+  "version": 1,
+  "routes": [
+    {
+      "path": "/_next/static/<*>",
+      "target": {
+        "kind": "Static"
+      },
+      "fallback": null
+    },
+    {
+      "path": "/favicon.ico",
+      "target": {
+        "kind": "Static"
+      },
+      "fallback": null
+    },
+    {
+      "path": "/<*>",
+      "target": {
+        "kind": "Compute",
+        "src": "default"
+      },
+      "fallback": null
+    }
+  ],
+  "computeResources": [
+    {
+      "name": "default",
+      "runtime": "nodejs20.x",
+      "entrypoint": "server.js"
+    }
+  ],
+  "framework": {
+    "name": "next",
+    "version": "$(node -e "console.log(require('./node_modules/next/package.json').version)")"
+  }
+}
+EOF
+
+echo ".amplify-hosting structure created successfully"
+ls -la "$OUTPUT_DIR"


### PR DESCRIPTION
## 概要
AmplifyのWEB_COMPUTEモードで `deploy-manifest.json` が自動生成されない問題を、ビルドスクリプトで手動生成する方式で解決。

## 変更内容

### frontend/next.config.ts
- `output: "standalone"` を再追加（standaloneビルドが `.amplify-hosting` 生成の前提）

### frontend/scripts/build-amplify.sh
- standaloneビルド出力を `.amplify-hosting/` 構造に変換するスクリプト
- `compute/default/` にサーバーファイル、`static/` に静的ファイルを配置
- `deploy-manifest.json` をNode.js 20ランタイムで生成

### amplify.yml
- buildフェーズで `build-amplify.sh` を実行
- `baseDirectory` を `frontend/.amplify-hosting` に変更

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)