### PR TITLE
fix(frontend): deploy-manifest.jsonからImageOptimizationルートを削除

### DIFF
--- a/frontend/scripts/build-amplify.sh
+++ b/frontend/scripts/build-amplify.sh
@@ -30,13 +30,6 @@ cat > "$OUTPUT_DIR/deploy-manifest.json" <<EOF
       }
     },
     {
-      "path": "/_next/image",
-      "target": {
-        "kind": "ImageOptimization",
-        "cacheControl": "public, max-age=3600, immutable"
-      }
-    },
-    {
       "path": "/*.*",
       "target": { "kind": "Static" },
       "fallback": { "kind": "Compute", "src": "default" }


### PR DESCRIPTION
## 概要
`imageSettings` 未指定の `ImageOptimization` ターゲットがバリデーションエラーになるため削除。

## エラー
```
The 'imageSettings' attribute must be specified for ImageOptimization targets.
```

## 修正内容
- `/_next/image` の `ImageOptimization` ルートを削除
- `/_next/image` は `/*.*` の fallback 経由で Compute が処理する

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)