### PR TITLE
fix(frontend): クイズ回答クリック時の自動次へ進む動作を削除

### DIFF
--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -48,9 +48,6 @@ function QuizContent() {
     const next = [...answers];
     next[current] = type;
     setAnswers(next);
-    if (current < questions.length - 1) {
-      setTimeout(() => setCurrent((c) => c + 1), 200);
-    }
   }
 
   async function handleSubmit() {


### PR DESCRIPTION
## 概要
回答をクリックすると自動的に次の問題へ進んでしまうUX問題を修正。

## 修正内容
- `handleSelect` 内の `setTimeout(() => setCurrent(...), 200)` を削除
- 「次へ」ボタンを明示的に押すまで次の問題に進まない動作に変更

## 合わせて対応（DynamoDB直接操作済み）
- 性格診断問題が18件重複登録されていたため、正しい6問のみに整理済み

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)