### PR TITLE
fix(backend): DynamoDB性格診断質問の重複投入バグを修正

### DIFF
--- a/backend/internal/repository/personality_dynamo.go
+++ b/backend/internal/repository/personality_dynamo.go
@@ -37,13 +37,14 @@ func (r *PersonalityRepository) FindAllQuestions(ctx context.Context) ([]model.P
 }
 
 func (r *PersonalityRepository) CountQuestions(ctx context.Context) (int64, error) {
-	out, err := r.db.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+	out, err := r.db.Scan(ctx, &dynamodb.ScanInput{
 		TableName: aws.String(r.table),
+		Select:    types.SelectCount,
 	})
 	if err != nil {
 		return 0, err
 	}
-	return *out.Table.ItemCount, nil
+	return int64(out.Count), nil
 }
 
 func (r *PersonalityRepository) SeedQuestions(ctx context.Context, questions []model.PersonalityQuestion) error {


### PR DESCRIPTION
## 概要

Lambda起動のたびに性格診断質問（6問）がDynamoDBに重複投入されるバグを修正。
クイズ画面で18問や24問など重複した質問が表示される原因。

## 変更内容

- `CountQuestions` の実装を `DescribeTable.ItemCount` → `Scan with Select:COUNT` に変更

### 原因詳細

`DescribeTable.ItemCount` はDynamoDBの**近似値（最大6時間遅延）**のため、
実際にデータが存在しても `0` を返すことがあった。
その結果 `SeedIfEmpty` が毎回「空」と誤判定してシードを実行し、6問ずつ蓄積していた。

## テスト計画

- [ ] ビルド確認（`go build ./...`）
- [ ] Lambda再デプロイ後、DynamoDBテーブルに重複が投入されないことを確認
- [ ] クイズ画面で正確に6問だけ表示されることを確認

## 残作業

- DynamoDBの `personality_questions` テーブルの重複データを手動削除し、正しい6件のみ残す

Closes #63